### PR TITLE
Fix wrong default title for UPNP files

### DIFF
--- a/src/com/miz/abstractclasses/BaseMovie.java
+++ b/src/com/miz/abstractclasses/BaseMovie.java
@@ -1,12 +1,12 @@
 package com.miz.abstractclasses;
 
+import android.content.Context;
+
 import java.io.File;
 import java.util.Locale;
 
 import com.miz.functions.MizLib;
 import com.miz.mizuu.MizuuApplication;
-
-import android.content.Context;
 
 public abstract class BaseMovie implements Comparable<BaseMovie> {
 
@@ -28,8 +28,10 @@ public abstract class BaseMovie implements Comparable<BaseMovie> {
 
 		// getTitle()
 		if (TITLE == null || TITLE.isEmpty()) {
-			File fileName = new File(FILEPATH);
-			TITLE = fileName.getName().substring(0, fileName.getName().lastIndexOf("."));
+			String temp = FILEPATH.contains("<MiZ>") ? FILEPATH.split("<MiZ>")[0] : FILEPATH;
+			File fileName = new File(temp);
+			int pointPosition=fileName.getName().lastIndexOf(".");
+			TITLE = pointPosition == -1 ? fileName.getName() : fileName.getName().substring(0, pointPosition);
 		} else {
 			if (ignorePrefixes) {
 				String temp = TITLE.toLowerCase(Locale.ENGLISH);


### PR DESCRIPTION
Hi Michell,
i have added new files from an UPNP Device. If the App failed to identify some Movies the Title of this Movies is extracted from the filepath in the BaseMovie-Class. The Problem is that the filepath of the UPNP-File is something complete different than the actual filename. 

In Example:
BaseMove-Class try to extract the title from the filepath e.g.: 
doku/Too Young To Die - Kurt Cobain (12.07.21_arte)<MiZ>http://192.168.1.10:50002/v/NDLNA/4504.avi
So the extracted title will be "4504".

To Fix this i extracted the title from the real filename instead of the UPNP-filepath.

regards,
David
