### PR TITLE
Use FullFilepath to identify TVShow-Episodes

### DIFF
--- a/src/com/miz/mizuu/fragments/ShowSeasonsFragment.java
+++ b/src/com/miz/mizuu/fragments/ShowSeasonsFragment.java
@@ -23,6 +23,10 @@ import java.util.Collections;
 import java.util.Comparator;
 
 import jcifs.smb.SmbFile;
+
+import android.support.v4.app.Fragment;
+import android.support.v4.content.LocalBroadcastManager;
+
 import android.animation.ObjectAnimator;
 import android.app.AlertDialog;
 import android.content.BroadcastReceiver;
@@ -39,8 +43,6 @@ import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
-import android.support.v4.app.Fragment;
-import android.support.v4.content.LocalBroadcastManager;
 import android.util.SparseIntArray;
 import android.view.ActionMode;
 import android.view.LayoutInflater;
@@ -1022,7 +1024,7 @@ public class ShowSeasonsFragment extends Fragment {
 		Intent i = new Intent();
 		i.setClass(getActivity(), IdentifyTvShow.class);
 		i.putExtra("rowId", shownEpisodes.get(selectedEpisodeIndex).getRowId());
-		i.putExtra("files", new String[]{shownEpisodes.get(selectedEpisodeIndex).getFilepath()});
+		i.putExtra("files", new String[]{shownEpisodes.get(selectedEpisodeIndex).getFullFilepath()});
 		i.putExtra("isShow", false);
 		startActivity(i);
 	}


### PR DESCRIPTION
So IdentifyTvShow-Activity can use the realname-Path of an UPNP-File.
In IdentifyTvShow in [ShowDetails.java#L239](https://github.com/MizzleDK/Mizuu/blob/master/src/com/miz/mizuu/ShowDetails.java#L239) also use the fullpath.

by the way congratulation! You are back on Google Play!!!
And thanks for this great App!!!

regards,
David
