### PR TITLE
Remove unnessesary refreshes in TvShowLibraryFragment

### DIFF
--- a/app/src/main/java/com/miz/mizuu/fragments/TvShowLibraryFragment.java
+++ b/app/src/main/java/com/miz/mizuu/fragments/TvShowLibraryFragment.java
@@ -181,6 +181,15 @@ public class TvShowLibraryFragment extends Fragment implements ActionBar.OnNavig
 
 		LocalBroadcastManager.getInstance(getActivity()).registerReceiver(mMessageReceiver, new IntentFilter(LocalBroadcastUtils.UPDATE_TV_SHOW_LIBRARY));
 		LocalBroadcastManager.getInstance(getActivity()).registerReceiver(mMessageReceiver, new IntentFilter("mizuu-shows-actor-search"));
+
+		loadData();
+	}
+
+	private void loadData() {
+		if (mTvShows.size() == 0)
+			forceLoaderLoad();
+		else
+			notifyDataSetChanged();
 	}
 
 	private void setupActionBar() {
@@ -343,16 +352,6 @@ public class TvShowLibraryFragment extends Fragment implements ActionBar.OnNavig
 		intent.putExtra("showId", mTvShows.get(mTvShowKeys.get(arg2)).getId());
 		intent.setClass(getActivity(), TvShowDetails.class);
 		startActivityForResult(intent, 0);
-	}
-
-	@Override
-	public void onResume() {
-		super.onResume();
-
-		if (mTvShows.size() == 0)
-			forceLoaderLoad();
-		else
-			notifyDataSetChanged();
 	}
 
 	@Override


### PR DESCRIPTION
Hi Mitchell,

thanks for your great work and the awesome Material Design polish!

I saw that the `TvShowLibraryFragment` gets refreshed multiple times. You can see this by go to a detail view of an TvShow and press the Back-button from the `TvShowDetails`-Activity. All the images getting reloaded within their fade-in animation. 

This is because `TvShowLibraryFragment.notifyDataSetChanged()` gets called multiple times.
In the `onResume()` method the `notifyDataSetChanged()` can be remove because you calling `forceLoaderLoad()` this results in an `AsyncTask` call in the `loaderCallbacks` where `showTvShowSection(0)` is called in the `onPostExecute()` method. And this will result in another `AsyncTask` call the `TvShowSectionLoader`. This will than call `sortTvShows()` on his `onPostExecute()`. 

And any `sortTvShows()` call will call `sortBy()` and in the end this will call the final `notifyDataSetChanged()`.
And for the last reason i also removed all `notifyDataSetChanged()` that came after a `sortTvShows()` call.

It´s just a fine-tune pull request, but it results in a much nicer transformation when you press Back from the TvShowDetails`-Activity.

regards,
david
