### PR TITLE
Bug: Try to remove TvShow twice in RECENTLY_AIRED

### DIFF
--- a/app/src/main/java/com/miz/loader/TvShowLoader.java
+++ b/app/src/main/java/com/miz/loader/TvShowLoader.java
@@ -324,13 +324,12 @@ public class TvShowLoader {
                         try {
                             cal.setTime(sdf.parse(latestEpisode));
                             cal.add(Calendar.MONTH, 3);
+                            if (cal.getTimeInMillis() < now) {
+                                mTvShowList.remove(i);
+                                i--;
+                                listSize--;
+                            }
                         } catch (ParseException e) {
-                            mTvShowList.remove(i);
-                            i--;
-                            listSize--;
-                        }
-
-                        if (cal.getTimeInMillis() < now) {
                             mTvShowList.remove(i);
                             i--;
                             listSize--;


### PR DESCRIPTION
If a `ParseException` is thrown the current shown already gets removed from `mTvShowList`. The old if-statement try to remove the show again, while `i` is already decremented in the catch-clause. This will result in an `ArrayIndexOutOfBoundsException`:

```
Caused by: java.lang.ArrayIndexOutOfBoundsException: length=63; index=-1
            at java.util.ArrayList.remove(ArrayList.java:405)
            at com.miz.loader.TvShowLoader$TvShowLoaderAsyncTask.doInBackground(TvShowLoader.java:336)
```

regards,
David
