### PR TITLE
nicer actionbar fading

### DIFF
--- a/app/src/main/java/com/miz/mizuu/fragments/TvShowDetailsFragment.java
+++ b/app/src/main/java/com/miz/mizuu/fragments/TvShowDetailsFragment.java
@@ -413,6 +413,7 @@ public class TvShowDetailsFragment extends Fragment {
                         @Override
                         public void onPaletteLoaded(int swatchColor) {
                             mToolbarColor = swatchColor;
+	                        ViewUtils.updateToolbarBackground(getActivity(), mToolbar, 0, thisShow.getTitle(), mToolbarColor);
                         }
                     });
 


### PR DESCRIPTION
This patch will result in a smoother Actionbar fading.
- Using a `GradientDrawable` on Lollipop, so the transparent StatusBar has enough contrast to the TvShow image.
- fading the title-textcolor instead of just set/unset the title depending on an fixed alpha value 
